### PR TITLE
Fix env vars in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,11 @@ jobs:
             - ~/.m2
           key: circleci-night-watch-planner-{{ checksum "optimizer/pom.xml" }}
 
-      - run: mvn -f optimizer/pom.xml package
+      - run:
+          name: Run tests
+          environment:
+            NWP_CLIENT_URL: http://localhost:1234
+          command: mvn -f optimizer/pom.xml package
 
       - store_test_results:
           path: optimizer/target/surefire-reports

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,9 @@ name: Java CI
 
 on: [push]
 
+env:
+  NWP_CLIENT_URL: "http://localhost:1234"
+
 jobs:
   build:
 

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,5 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-
-*.production

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "build:railway": "sh ./scripts/railwayenv.sh && tsc && vite build",
     "preview": "vite preview",
     "start": "serve dist -s -n -L -p $PORT",
     "lint": "eslint src && tsc --noEmit",

--- a/client/scripts/railwayenv.sh
+++ b/client/scripts/railwayenv.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo VITE_PLAN_REST_API_HOST=$RAILWAY_SERVICE_NWP_OPTA_URL > .env.production

--- a/optimizer/Dockerfile
+++ b/optimizer/Dockerfile
@@ -13,11 +13,8 @@ RUN chmod +x ./mvnw
 # download the dependency if needed or if the pom file is changed
 RUN ./mvnw dependency:go-offline -B
 
-# Define the RAILWAY_SERVICE_NWP_FRONTEND_URL build argument
-ARG RAILWAY_SERVICE_NWP_FRONTEND_URL
-
 # Set the NWP_CLIENT_URL environment variable
-ENV NWP_CLIENT_URL=$RAILWAY_SERVICE_NWP_FRONTEND_URL
+ARG NWP_CLIENT_URL
 
 COPY src src
 

--- a/optimizer/docker-compose.yml
+++ b/optimizer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     - "3000:3000"
     environment:
     - PORT=3000
-    - RAILWAY_SERVICE_NWP_FRONTEND_URL=http://localhost:1234
+    - NWP_CLIENT_URL=http://localhost:1234
     depends_on:
     - swagger
   swagger:

--- a/optimizer/src/main/resources/application.production.yml
+++ b/optimizer/src/main/resources/application.production.yml
@@ -1,8 +1,0 @@
-server:
-  port: 3000
-client:
-  url: ${NWP_CLIENT_URL}
-logging:
-  level:
-    #ROOT: DEBUG
-    org.optaplanner: debug

--- a/optimizer/src/main/resources/application.yml
+++ b/optimizer/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   port: 3000
 client:
-  url: http://localhost:1234
+  url: ${NWP_CLIENT_URL}
 logging:
   level:
     #ROOT: DEBUG


### PR DESCRIPTION
Revert unnecessary env var boilerplate from the client and remove the ones named `RAILWAY_whatever` from the backend.